### PR TITLE
Add Swagger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Esta aplicacion permite registrar estudiantes, cursos y sus calificaciones en un
 3. La API quedara disponible en `http://localhost:8080`.
 
 La consola de H2 esta habilitada en `/h2-console`.
+La documentacion Swagger UI esta disponible en `/swagger-ui.html`.
 
 ## Uso de la API
 - **Crear estudiante**

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,17 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/org/sci/serviciogestioncalificaciones/ServicioGestionCalificacionesApplication.java
+++ b/src/main/java/org/sci/serviciogestioncalificaciones/ServicioGestionCalificacionesApplication.java
@@ -2,7 +2,11 @@ package org.sci.serviciogestioncalificaciones;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
+@OpenAPIDefinition(info = @Info(title = "API Gestion Calificaciones", version = "1.0",
+        description = "Documentacion de la API"))
 @SpringBootApplication
 public class ServicioGestionCalificacionesApplication {
 

--- a/src/main/java/org/sci/serviciogestioncalificaciones/controller/ApiController.java
+++ b/src/main/java/org/sci/serviciogestioncalificaciones/controller/ApiController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
 @RequestMapping("/api")
@@ -31,31 +32,37 @@ public class ApiController {
     }
 
     @PostMapping("/students")
+    @Operation(summary = "Crear estudiante")
     public Student createStudent(@RequestBody Student student) {
         return studentService.save(student);
     }
 
     @GetMapping("/students")
+    @Operation(summary = "Listar estudiantes")
     public List<Student> getStudents() {
         return studentService.findAll();
     }
 
     @PostMapping("/courses")
+    @Operation(summary = "Crear curso")
     public Course createCourse(@RequestBody Course course) {
         return courseService.save(course);
     }
 
     @GetMapping("/courses")
+    @Operation(summary = "Listar cursos")
     public List<Course> getCourses() {
         return courseService.findAll();
     }
 
     @PostMapping("/enrollments")
+    @Operation(summary = "Matricular estudiante")
     public Enrollment createEnrollment(@RequestBody Enrollment enrollment) {
         return enrollmentService.save(enrollment);
     }
 
     @GetMapping("/courses/{id}/enrollments")
+    @Operation(summary = "Consultar notas por curso")
     public List<Enrollment> getEnrollmentsByCourse(@PathVariable Long id) {
         return enrollmentService.findByCourseId(id);
     }


### PR DESCRIPTION
## Summary
- set up Swagger with springdoc-openapi-starter-webmvc-ui
- expose OpenAPI info in the main application class
- document endpoints with @Operation annotations
- mention Swagger UI in README

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68502e54bc3c833282fa5d689b8bf02d